### PR TITLE
ReadツールをRead(*)で全許可に設定

### DIFF
--- a/settings.template.json
+++ b/settings.template.json
@@ -138,6 +138,11 @@
       }
     ]
   },
+  "permissions": {
+    "allow": [
+      "Read(*)"
+    ]
+  },
   "statusLine": {
     "type": "command",
     "command": "echo 'Claude Code'"


### PR DESCRIPTION
## 変更内容

`settings.template.json` に `permissions.allow` を追加し、全パスへの `Read` ツールを許可プロンプトなしで実行できるよう設定。

## 変更理由

Claude Code アプリでファイル読み込み時に都度許可プロンプトが表示されるのを解消するため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)